### PR TITLE
fix: mutation_root_name when there is no mutation type

### DIFF
--- a/lib/graphql_schema.rb
+++ b/lib/graphql_schema.rb
@@ -15,7 +15,9 @@ class GraphQLSchema
   end
 
   def mutation_root_name
-    @mutation_root_name ||= @hash.fetch('mutationType', {}).fetch('name')
+    if mutation_type = @hash.fetch('mutationType')
+      mutation_type.fetch('name')
+    end
   end
 
   def types

--- a/test/graphql_schema_test.rb
+++ b/test/graphql_schema_test.rb
@@ -20,6 +20,11 @@ class GraphQLSchemaTest < Minitest::Test
     assert_equal ['Mutation', 'QueryRoot'], @schema.types.select { |type| @schema.root_name?(type.name) }.map(&:name)
   end
 
+  def test_no_mutation_root
+    schema = GraphQLSchema.new(Support::Schema.introspection_result(Support::Schema::NoMutationSchema))
+    assert_equal nil, schema.mutation_root_name
+  end
+
   def test_camelize_name
     assert_equal 'queryRoot', query_root.camelize_name
     assert_equal 'getString', get_string_field.camelize_name

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -105,8 +105,14 @@ module Support
       resolve_type ->(obj, ctx) {}
     end
 
-    def self.introspection_result
-      GraphQL::Query.new(ExampleSchema, GraphQL::Introspection::INTROSPECTION_QUERY).result
+    NoMutationSchema = GraphQL::Schema.define do
+      query QueryType
+      orphan_types [StringEntryType, IntegerEntryType]
+      resolve_type ->(obj, ctx) {}
+    end
+
+    def self.introspection_result(schema = ExampleSchema)
+      GraphQL::Query.new(schema, GraphQL::Introspection::INTROSPECTION_QUERY).result
     end
   end
 end


### PR DESCRIPTION
@mikkoh please review

## Problem

I get the following exception when there is no GraphQL mutation type:

```
NoMethodError: undefined method `fetch' for nil:NilClass
    /Users/dylansmith/src/graphql_schema/lib/graphql_schema.rb:18:in `mutation_root_name'
    /Users/dylansmith/src/graphql_schema/test/graphql_schema_test.rb:25:in `test_no_mutation_root'
```

because the default argument to fetch in mutation_root_name (i.e. `@hash.fetch('mutationType', {})`) wasn't being used since the mutationType key exists, it is just nil.

## Solution

Use a condition to only call `.fetch('name')` if the mutation type is truthy.