### PR TITLE
feature: type_from_name

### DIFF
--- a/lib/graphql_schema.rb
+++ b/lib/graphql_schema.rb
@@ -25,7 +25,8 @@ class GraphQLSchema
   end
 
   def type_from_name(type_name)
-    @types.find { |type| type.name == type_name }
+    @types_by_name ||= types.map { |type| [type.name, type] }.to_h
+    @types_by_name[type_name]
   end
 
   module NamedHash

--- a/lib/graphql_schema.rb
+++ b/lib/graphql_schema.rb
@@ -24,9 +24,8 @@ class GraphQLSchema
     @types ||= @hash.fetch('types').map{ |type_hash| TypeDefinition.new(type_hash) }.sort_by(&:name)
   end
 
-  def type_from_name(type_name)
+  def types_by_name
     @types_by_name ||= types.map { |type| [type.name, type] }.to_h
-    @types_by_name[type_name]
   end
 
   module NamedHash

--- a/lib/graphql_schema.rb
+++ b/lib/graphql_schema.rb
@@ -24,6 +24,10 @@ class GraphQLSchema
     @types ||= @hash.fetch('types').map{ |type_hash| TypeDefinition.new(type_hash) }.sort_by(&:name)
   end
 
+  def type_from_name(type_name)
+    @types.find { |type| type.name == type_name }
+  end
+
   module NamedHash
     def name
       @hash.fetch('name')

--- a/test/graphql_schema_test.rb
+++ b/test/graphql_schema_test.rb
@@ -134,11 +134,6 @@ class GraphQLSchemaTest < Minitest::Test
     assert_equal nil, type('QueryRoot').fields_by_name['does_not_exist']
   end
 
-  def test_type_from_name
-    assert_equal type('SetIntegerInput'), @schema.type_from_name('SetIntegerInput')
-    assert_equal nil, @schema.type_from_name('IDoNotExist')
-  end
-
   def test_type_by_name
     assert_equal type('SetIntegerInput'), @schema.types_by_name['SetIntegerInput']
     assert_equal nil, @schema.types_by_name['IDoNotExist']

--- a/test/graphql_schema_test.rb
+++ b/test/graphql_schema_test.rb
@@ -134,6 +134,11 @@ class GraphQLSchemaTest < Minitest::Test
     assert_equal nil, type('QueryRoot').fields_by_name['does_not_exist']
   end
 
+  def test_type_from_name
+    assert_equal type('SetIntegerInput'), @schema.type_from_name('SetIntegerInput')
+    assert_equal nil, @schema.type_from_name('IDoNotExist')
+  end
+
   def test_description
     assert_equal 'Time since epoch in seconds', type('Time').description
     assert_nil type('StringEntry').description

--- a/test/graphql_schema_test.rb
+++ b/test/graphql_schema_test.rb
@@ -139,6 +139,11 @@ class GraphQLSchemaTest < Minitest::Test
     assert_equal nil, @schema.type_from_name('IDoNotExist')
   end
 
+  def test_type_by_name
+    assert_equal type('SetIntegerInput'), @schema.types_by_name['SetIntegerInput']
+    assert_equal nil, @schema.types_by_name['IDoNotExist']
+  end
+
   def test_description
     assert_equal 'Time since epoch in seconds', type('Time').description
     assert_nil type('StringEntry').description


### PR DESCRIPTION
This PR just adds a function `type_from_name` onto schema which can be used to query for a type based on the name of the type.