### PR TITLE
Feature: field_from_name on TypeDefinition

### DIFF
--- a/lib/graphql_schema.rb
+++ b/lib/graphql_schema.rb
@@ -209,9 +209,8 @@ class GraphQLSchema
       include_deprecated ? @fields : @fields.reject(&:deprecated?)
     end
 
-    def field_from_name(field_name, include_deprecated: false)
-      @fields_by_name ||= fields(include_deprecated: include_deprecated).map{ |field| [field.name, field]}.to_h
-      @fields_by_name[field_name]
+    def fields_by_name
+      @fields_by_name ||= fields(include_deprecated: true).map{ |field| [field.name, field]}.to_h
     end
 
     def input_fields

--- a/lib/graphql_schema.rb
+++ b/lib/graphql_schema.rb
@@ -209,6 +209,11 @@ class GraphQLSchema
       include_deprecated ? @fields : @fields.reject(&:deprecated?)
     end
 
+    def field_from_name(field_name, include_deprecated: false)
+      @fields_by_name ||= fields(include_deprecated: include_deprecated).map{ |field| [field.name, field]}.to_h
+      @fields_by_name[field_name]
+    end
+
     def input_fields
       @input_fields ||= @hash.fetch('inputFields').map{ |field_hash| InputValue.new(field_hash) }
     end

--- a/test/graphql_schema_test.rb
+++ b/test/graphql_schema_test.rb
@@ -128,6 +128,11 @@ class GraphQLSchemaTest < Minitest::Test
     assert_equal false, field('QueryRoot', 'keys').type.enum?
   end
 
+  def test_field_from_name?
+    assert_equal get_string_field, type('QueryRoot').field_from_name('get_string')
+    assert_equal nil, type('QueryRoot').field_from_name('does_not_exist')
+  end
+
   def test_description
     assert_equal 'Time since epoch in seconds', type('Time').description
     assert_nil type('StringEntry').description

--- a/test/graphql_schema_test.rb
+++ b/test/graphql_schema_test.rb
@@ -128,9 +128,10 @@ class GraphQLSchemaTest < Minitest::Test
     assert_equal false, field('QueryRoot', 'keys').type.enum?
   end
 
-  def test_field_from_name?
-    assert_equal get_string_field, type('QueryRoot').field_from_name('get_string')
-    assert_equal nil, type('QueryRoot').field_from_name('does_not_exist')
+  def test_fields_by_name
+    assert_equal get_string_field, type('QueryRoot').fields_by_name['get_string']
+    assert_equal get_field, type('QueryRoot').fields_by_name['get']
+    assert_equal nil, type('QueryRoot').fields_by_name['does_not_exist']
   end
 
   def test_description
@@ -192,6 +193,10 @@ class GraphQLSchemaTest < Minitest::Test
 
   def query_root
     type('QueryRoot')
+  end
+
+  def get_field
+    field('QueryRoot', 'get')
   end
 
   def get_string_field


### PR DESCRIPTION
This PR adds `field_from_name` onto `TypeDefinition`.

I don't like how `include_deprecated` is handled but I'm not sure there's a nicer way to handle it.