### PR TITLE
Sort Input Fields by name

### DIFF
--- a/lib/graphql_schema.rb
+++ b/lib/graphql_schema.rb
@@ -205,7 +205,7 @@ class GraphQLSchema
     end
 
     def input_fields
-      @input_fields ||= @hash.fetch('inputFields').map{ |field_hash| InputValue.new(field_hash) }
+      @input_fields ||= @hash.fetch('inputFields').map{ |field_hash| InputValue.new(field_hash) }.sort_by(&:name)
     end
 
     def required_input_fields

--- a/test/graphql_schema_test.rb
+++ b/test/graphql_schema_test.rb
@@ -72,7 +72,7 @@ class GraphQLSchemaTest < Minitest::Test
   end
 
   def test_input_fields
-    assert_equal %w(key value ttl negate), type('SetIntegerInput').input_fields.map(&:name)
+    assert_equal %w(key negate ttl value), type('SetIntegerInput').input_fields.map(&:name)
   end
 
   def test_required_input_fields
@@ -80,7 +80,7 @@ class GraphQLSchemaTest < Minitest::Test
   end
 
   def test_optional_input_fields
-    assert_equal %w(ttl negate), type('SetIntegerInput').optional_input_fields.map(&:name)
+    assert_equal %w(negate ttl), type('SetIntegerInput').optional_input_fields.map(&:name)
   end
 
   def test_default_value_input_fields


### PR DESCRIPTION
This is the only array that isn't sorted by name.

Unless there was a specific reason it, the consistency is improved by this.