### PR TITLE
Add to_h to expose data hash

### DIFF
--- a/lib/graphql_schema.rb
+++ b/lib/graphql_schema.rb
@@ -49,6 +49,10 @@ class GraphQLSchema
       @hash.fetch('description')
     end
 
+    def to_h
+      @hash
+    end
+
     private
 
     def split_name

--- a/test/graphql_schema_test.rb
+++ b/test/graphql_schema_test.rb
@@ -132,6 +132,33 @@ class GraphQLSchemaTest < Minitest::Test
     assert_equal 'Get an entry of any type with the given key', field('QueryRoot', 'get_entry').description
   end
 
+  def test_to_h
+    assert_equal({
+      'kind' => 'SCALAR',
+      'name' => 'Time',
+      'description' => 'Time since epoch in seconds',
+      'fields' => nil,
+      'inputFields' => nil,
+      'interfaces' => nil,
+      'enumValues' => nil,
+      'possibleTypes' => nil
+    }, type('Time').to_h)
+
+    assert_equal({
+      'name' => 'negate',
+      'description' => nil,
+      'type' => {'kind' => 'SCALAR', 'name' => 'Boolean', 'ofType' => nil },
+      'defaultValue' => 'false'
+    }, input_field('SetIntegerInput', 'negate').to_h)
+
+    assert_equal({
+      'name' => 'INTEGER',
+      'description' => nil,
+      'isDeprecated' => false,
+      'deprecationReason' => nil
+    }, type('KeyType').enum_values.first.to_h)
+  end
+
   private
 
   def type(name)


### PR DESCRIPTION
Use case: I'm working on schema documentation via Jekyll and it requires a hash for data access in templates so this is a much quicker method to get there instead of building up a hash which already exists.