### PR TITLE
Fix TypeDefinition#fields for types without fields (e.g. union)

### DIFF
--- a/lib/graphql_schema.rb
+++ b/lib/graphql_schema.rb
@@ -204,6 +204,7 @@ class GraphQLSchema
 
   class TypeDefinition < Type
     def fields(include_deprecated: false)
+      return unless @hash.fetch('fields')
       @fields ||= @hash.fetch('fields').map{ |field_hash| Field.new(field_hash) }
       include_deprecated ? @fields : @fields.reject(&:deprecated?)
     end

--- a/test/graphql_schema_test.rb
+++ b/test/graphql_schema_test.rb
@@ -43,6 +43,10 @@ class GraphQLSchemaTest < Minitest::Test
     assert_equal 'NOT_FOUND', not_found_value.upcase_name
   end
 
+  def test_nil_fields
+    assert_nil type('KeyType').fields
+  end
+
   def test_deprecated_fields
     deprecated = query_root.fields(include_deprecated: true) - query_root.fields
     assert_equal %w(get), deprecated.map(&:name)


### PR DESCRIPTION
## Problem

I noticed from https://github.com/Shopify/graphql_java_gen/issues/9 that calling fields on a union type was resulting in an error in graphql_schema.  I think it should just return `nil` like it is in the schema.

## Solution

Add an early return for the case where the fields array is `nil` in the schema.