### PR TITLE
Revert "Sort Input Fields by name"

### DIFF
--- a/lib/graphql_schema.rb
+++ b/lib/graphql_schema.rb
@@ -210,7 +210,7 @@ class GraphQLSchema
     end
 
     def input_fields
-      @input_fields ||= @hash.fetch('inputFields').map{ |field_hash| InputValue.new(field_hash) }.sort_by(&:name)
+      @input_fields ||= @hash.fetch('inputFields').map{ |field_hash| InputValue.new(field_hash) }
     end
 
     def required_input_fields

--- a/test/graphql_schema_test.rb
+++ b/test/graphql_schema_test.rb
@@ -76,7 +76,7 @@ class GraphQLSchemaTest < Minitest::Test
   end
 
   def test_input_fields
-    assert_equal %w(key negate ttl value), type('SetIntegerInput').input_fields.map(&:name)
+    assert_equal %w(key value ttl negate), type('SetIntegerInput').input_fields.map(&:name)
   end
 
   def test_required_input_fields
@@ -84,7 +84,7 @@ class GraphQLSchemaTest < Minitest::Test
   end
 
   def test_optional_input_fields
-    assert_equal %w(negate ttl), type('SetIntegerInput').optional_input_fields.map(&:name)
+    assert_equal %w(ttl negate), type('SetIntegerInput').optional_input_fields.map(&:name)
   end
 
   def test_default_value_input_fields


### PR DESCRIPTION
Reverts Shopify/graphql_schema#7

Input fields are already declared in a stable and quasi-semantic order in the schema so we don't need to sort them.