### PR TITLE
Feat: Add support for Directives

### DIFF
--- a/lib/graphql_schema.rb
+++ b/lib/graphql_schema.rb
@@ -227,12 +227,18 @@ class GraphQLSchema
     include NamedHash
     include WithArgs
 
+    BUILTIN = %w(skip include deprecated).to_set
+
     def initialize(directive)
       @hash = directive
     end
 
     def locations
       @hash.fetch('locations')
+    end
+
+    def builtin?
+      BUILTIN.include?(name)
     end
   end
 

--- a/test/graphql_schema_test.rb
+++ b/test/graphql_schema_test.rb
@@ -169,6 +169,9 @@ class GraphQLSchemaTest < Minitest::Test
     assert_equal ["FIELD"], example_directive.locations
     refute example_directive.builtin?
     assert directive("skip").builtin?
+    assert directive("include").builtin?
+    assert directive("deprecated").builtin?
+    assert_equal 4, @schema.directives.length
   end
 
   def test_to_h

--- a/test/graphql_schema_test.rb
+++ b/test/graphql_schema_test.rb
@@ -162,6 +162,13 @@ class GraphQLSchemaTest < Minitest::Test
     assert_equal 'Get an entry of any type with the given key', field('QueryRoot', 'get_entry').description
   end
 
+  def test_directives
+    example_directive = directive("directiveExample")
+    assert_equal %w(input), example_directive.args.map(&:name)
+    assert_equal "A nice runtime customization", example_directive.description
+    assert_equal ["FIELD"], example_directive.locations
+  end
+
   def test_to_h
     assert_equal({
       'kind' => 'SCALAR',
@@ -197,6 +204,12 @@ class GraphQLSchemaTest < Minitest::Test
 
   def field(type_name, field_name)
     type(type_name).fields(include_deprecated: true).find { |field| field.name == field_name }
+  end
+
+  def directive(directive_name)
+    @schema.directives.find do |dir|
+      dir.name == directive_name
+    end
   end
 
   def input_field(type_name, field_name)

--- a/test/graphql_schema_test.rb
+++ b/test/graphql_schema_test.rb
@@ -167,6 +167,8 @@ class GraphQLSchemaTest < Minitest::Test
     assert_equal %w(input), example_directive.args.map(&:name)
     assert_equal "A nice runtime customization", example_directive.description
     assert_equal ["FIELD"], example_directive.locations
+    refute example_directive.builtin?
+    assert directive("skip").builtin?
   end
 
   def test_to_h

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -98,9 +98,16 @@ module Support
       end
     end
 
+    class DirectiveExample < GraphQL::Schema::Directive
+      description "A nice runtime customization"
+      locations FIELD
+      argument :input, !SetIntegerInput, required: true
+    end
+
     ExampleSchema = GraphQL::Schema.define do
       query QueryType
       mutation MutationType
+      directive(DirectiveExample)
       orphan_types [StringEntryType, IntegerEntryType]
       resolve_type ->(obj, ctx) {}
     end


### PR DESCRIPTION
This PR adds support for parsing graphql directives. 

The `#directives` method on the schema returns instances of the `Directive` class, which responds to the following methods: 
- args
- description
- locations
- name
- builtin?