### PR TITLE
Move arg helpers to WithArgs module.

### DIFF
--- a/lib/graphql_schema.rb
+++ b/lib/graphql_schema.rb
@@ -38,6 +38,14 @@ class GraphQLSchema
     def args
       @args ||= @hash.fetch('args').map{ |arg_hash| InputValue.new(arg_hash) }
     end
+
+    def required_args
+      @required_args ||= args.select{ |arg| arg.type.non_null? }
+    end
+
+    def optional_args
+      @optional_args ||= args.reject{ |arg| arg.type.non_null? }
+    end
   end
 
   module NamedHash
@@ -109,14 +117,6 @@ class GraphQLSchema
 
     def initialize(field_hash)
       @hash = field_hash
-    end
-
-    def required_args
-      @required_args ||= args.select{ |arg| arg.type.non_null? }
-    end
-
-    def optional_args
-      @optional_args ||= args.reject{ |arg| arg.type.non_null? }
     end
 
     def type

--- a/test/graphql_schema_test.rb
+++ b/test/graphql_schema_test.rb
@@ -164,7 +164,9 @@ class GraphQLSchemaTest < Minitest::Test
 
   def test_directives
     example_directive = directive("directiveExample")
-    assert_equal %w(input), example_directive.args.map(&:name)
+    assert_equal %w(input enabled), example_directive.args.map(&:name)
+    assert_equal %w(input), example_directive.required_args.map(&:name)
+    assert_equal %w(enabled), example_directive.optional_args.map(&:name)
     assert_equal "A nice runtime customization", example_directive.description
     assert_equal ["FIELD"], example_directive.locations
     refute example_directive.builtin?

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -102,6 +102,7 @@ module Support
       description "A nice runtime customization"
       locations FIELD
       argument :input, !SetIntegerInput, required: true
+      argument :enabled, Boolean, required: false
     end
 
     ExampleSchema = GraphQL::Schema.define do


### PR DESCRIPTION
Extracts the helpful `required_args` and `optional_args` methods to the `WithArgs` module for use with directives.